### PR TITLE
Satis auto build config & Admin error scroll

### DIFF
--- a/.github/workflows/composer-satis-build.yml
+++ b/.github/workflows/composer-satis-build.yml
@@ -1,0 +1,12 @@
+name: Build Composer Satis
+on:
+  push
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  build:
+    uses: humanelement/composer-repo/.github/workflows/composer-satis-build.yml@composer-satis-build-v1
+    with:
+      s3-bucket: ${{ vars.HE_COMPOSER_SATIS_S3_BUCKET }}
+      satis-json: ${{ vars.HE_COMPOSER_SATIS_JSON }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# 2.0.5
+
+## 2023-09-07
+Rob Simmons <rsimmons@human-element.com>
+* Adds form-mixin so that when you save an admin form (e.g. product, category forms), we scroll to the error.
+* Sets up satis auto-build
+
+--------------------------------------------------------
+
+# 2.0.4
+
+## 2023-09-07
+Rob Simmons <rsimmons@human-element.com>
+* Initial entry in changelog
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ For example this would create a `live-debugging.log` file in your `/var/log` for
 ```php
 \HumanElement\Base\Model\Logger::log('code hit this path', 'live-debugging.log');
 ```
+
+
+## Extra Features
+- When saving an admin form (e.g. product, category), if there is an error, it will now scroll to that error.
+

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "human-element/module-base",
     "description": "Human-Element Base",
     "type": "magento2-module",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "license": [
         "GPL-3.0"
     ],

--- a/view/base/requirejs-config.js
+++ b/view/base/requirejs-config.js
@@ -1,0 +1,9 @@
+var config = {
+    config: {
+        mixins: {
+            'Magento_Ui/js/form/form': {
+                'HumanElement_Base/js/form/form-mixin': true
+            }
+        }
+    }
+};

--- a/view/base/web/js/form/form-mixin.js
+++ b/view/base/web/js/form/form-mixin.js
@@ -1,0 +1,30 @@
+define(function () {
+    'use strict';
+
+    var mixin = {
+        /**
+         * Mixin: now scrolls error into view
+         *
+         * Tries to set focus on first invalid form field.
+         *
+         * @returns {Object}
+         */
+        focusInvalid: function () {
+            var invalidField = _.find(this.delegate('checkInvalid'));
+
+            if (!_.isUndefined(invalidField) && _.isFunction(invalidField.focused)) {
+                invalidField.focused(true);
+
+                document.querySelector('#error-message-tooltip').scrollIntoView({
+                    behavior: 'smooth'
+                });
+            }
+
+            return this;
+        }
+    };
+
+    return function (target) {
+        return target.extend(mixin);
+    };
+});


### PR DESCRIPTION
- adds Satis build config
- adds a bit of JS that makes it scroll to the error when you are submitting an admin form, e.g. product or category forms
- no one requested this functionality, I've just always thought it would be a useful enhancement to Magento admin forms, so you don't just sit there thinking the Save button is unresponsive.

I did some research and ensured that the function I'm overriding for this is identical at least back to Magento 2.4.2-p2, so it should be safe to use.

Though I'm committing the satis auto-build code, I am not committing directly to master, and will thus not be creating the tags (which I believe will trigger the actual auto-satis-build process).